### PR TITLE
Add avsc to benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,45 +6,59 @@ A simple benchmark test to measure the performance of the following Node.js modu
 * [msgpack](https://www.npmjs.com/package/msgpack)
 * [msgpack-js](https://www.npmjs.com/package/msgpack-js)
 * [pson](https://www.npmjs.com/package/pson)
+* [avsc](https://www.npmjs.com/package/avsc)
 
 ## Results
 
     $ node benchmark.js
 
-    no binary buffers msgpack.pack: 443ms
-    no binary buffers msgpack.unpack: 301ms
+    no binary buffers msgpack.pack: 446.188ms
+    no binary buffers msgpack.unpack: 347.430ms
 
-    no binary buffers msgpack-js.encode: 723ms
-    no binary buffers msgpack-js.decode: 264ms
+    no binary buffers msgpack-js.encode: 675.531ms
+    no binary buffers msgpack-js.decode: 298.495ms
 
-    no binary buffers pson.encode: 1541ms
-    no binary buffers pson.decode: 280ms
+    no binary buffers pson.encode: 1208.759ms
+    no binary buffers pson.decode: 276.973ms
 
-    no binary buffers JSON.stringify: 135ms
-    no binary buffers JSON.parse: 102ms
+    no binary buffers avsc.toBuffer: 57.868ms // See [1].
+    no binary buffers avsc.fromBuffer: 20.666ms
 
-    no binary buffers msgpack5.encode: 29189ms
-    no binary buffers msgpack5.decode: 14004ms
+    no binary buffers JSON.stringify: 93.410ms
+    no binary buffers JSON.parse: 93.165ms
+
+    no binary buffers msgpack5.encode: 22254.455ms
+    no binary buffers msgpack5.decode: 12134.576ms
 
     ---
 
-    with binary buffers msgpack.pack: 518ms
-    with binary buffers msgpack.unpack: 547ms
+    with binary buffers msgpack.pack: 498.184ms
+    with binary buffers msgpack.unpack: 541.152ms
 
-    with binary buffers msgpack-js.encode: 941ms
-    with binary buffers msgpack-js.decode: 396ms
+    with binary buffers msgpack-js.encode: 878.312ms
+    with binary buffers msgpack-js.decode: 420.872ms
 
-    with binary buffers pson.encode: 1826ms
-    with binary buffers pson.decode: 377ms
+    with binary buffers pson.encode: 1596.219ms
+    with binary buffers pson.decode: 393.904ms
 
-    // Note: JSON encoding binary buffers is not relevant
-    // as binary data should be encoded manually in a nother format
-    // For completeness however, this has been left in
-    with binary buffers JSON.stringify: 6045ms
-    with binary buffers JSON.parse: 735ms
+    with binary buffers avsc.toBuffer: 85.295ms
+    with binary buffers avsc.fromBuffer: 75.181ms
 
-    with binary buffers msgpack5.encode: 43991ms
-    with binary buffers msgpack5.decode: 15891ms
+    with binary buffers JSON.stringify: 5620.344ms // See [2].
+    with binary buffers JSON.parse: 788.695ms
+
+    with binary buffers msgpack5.encode: 33868.102ms
+    with binary buffers msgpack5.decode: 11560.702ms
+
+
+Notes:
+
+1.  `avsc` expects the data's structure to be defined upfront using an Avro
+    schema. See [here](https://github.com/mtth/avsc#examples) for examples and
+    more information.
+2.  JSON encoding binary buffers is not relevant as binary data should be
+    encoded manually in another format. For completeness however, this has been
+    left in.
 
 # About
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "msgpack-js": "0.3.0",
     "msgpack": "1.0.2",
     "msgpack5": "3.2.0",
-    "pson": "2.0.0"
+    "pson": "2.0.0",
+    "avsc": "3.0.2"
   },
   "engines": {
     "iojs": "4.2.2"


### PR DESCRIPTION
See https://github.com/mattheworiordan/nodejs-encoding-benchmarks/issues/1.

This required changing the name of one of the fields in the test data:
`19` to `a19`, Avro doesn't allow numbers as first character in names.
(This change has no impact on benchmark results.)
